### PR TITLE
fix: format number in E164 in api and app

### DIFF
--- a/api/helpers/phones/index.js
+++ b/api/helpers/phones/index.js
@@ -13,7 +13,7 @@ const sendSMS = async (message, numbers) => {
       client.messages.create({
         body: message,
         from: twilioPhone,
-        to: num,
+        to: num
       })
     )
   );
@@ -41,27 +41,19 @@ exports.normalizePhone = (phone, country = "AR") => {
   let finalCountry = country;
 
   try {
-    //If the phone number is already formated with a country code it wont throw any error
-    if (isUYPhone(phone)) {
-      finalCountry = "UY";
-      number = phoneUtil.parseAndKeepRawInput(phone, finalCountry);
-    } else {
-      number = phoneUtil.parseAndKeepRawInput(phone, country);
-
-      // We remove in Argentina numbers the leading 9 before the area code
-      // We normalize this so we don't have issues with 9 numbers
-      // The 9 is NOT required to send SMS
-      if (number.getNationalNumber().toString()[0] === "9") {
-        const properNumber = number
-          .getNationalNumber()
-          .toString()
-          .substring(1);
-        number = phoneUtil.parseAndKeepRawInput(properNumber, country);
-      }
+    number = phoneUtil.parseAndKeepRawInput(phone, country);
+    // We remove in Argentina numbers the leading 9 before the area code
+    // We normalize this so we don't have issues with 9 numbers
+    // The 9 is NOT required to send SMS
+    if (number.getNationalNumber().toString()[0] === "9") {
+      const properNumber = number
+        .getNationalNumber()
+        .toString()
+        .substring(1);
+      number = phoneUtil.parseAndKeepRawInput(properNumber, country);
     }
   } catch (error) {
-    // If the number above threw error we asume that it's from Argentina ( in the future we should get it from the admin number )
-    console.log("===== ERROR on parsing normalidez phone =====");
+    console.log("===== ERROR on parsing normalized phone =====");
     if (error.message === "Invalid country calling code") {
       // Get first number from the phone
       const { 0: firstNumber } = phone;
@@ -76,14 +68,6 @@ exports.normalizePhone = (phone, country = "AR") => {
     }
   }
 
-  // Format the phone number to international format
-  return phoneUtil.format(number, PNF.INTERNATIONAL);
-};
-
-const isUYPhone = phone => {
-  const trimPhone = phone.replace(/\s/g, "");
-  return (
-    (trimPhone.length === 9 && trimPhone.substr(0, 2) === "09") ||
-    trimPhone.includes("+598")
-  );
+  // Format the phone number to E164 format
+  return phoneUtil.format(number, PNF.E164);
 };

--- a/app/helpers/phones/index.js
+++ b/app/helpers/phones/index.js
@@ -1,11 +1,11 @@
 const accountSid = process.env.TWILIO_ACCOUNT_SID;
 const authToken = process.env.TWILIO_AUTHTOKEN;
 const twilioPhone = process.env.TWILIO_PHONE_NUMBER;
-const client = require("twilio")(accountSid, authToken);
-const allSettled = require("promise.allsettled");
-const phoneUtil = require("google-libphonenumber").PhoneNumberUtil.getInstance();
-const PNF = require("google-libphonenumber").PhoneNumberFormat;
-const { customError } = require("../errorHandler");
+const client = require('twilio')(accountSid, authToken);
+const allSettled = require('promise.allsettled');
+const phoneUtil = require('google-libphonenumber').PhoneNumberUtil.getInstance();
+const PNF = require('google-libphonenumber').PhoneNumberFormat;
+const {customError} = require('../errorHandler');
 
 const sendSMS = async (message, numbers) => {
   const results = await allSettled(
@@ -14,16 +14,16 @@ const sendSMS = async (message, numbers) => {
         body: message,
         from: twilioPhone,
         to: num,
-      })
-    )
+      }),
+    ),
   );
 
   const errors = results
-    .filter(p => p.status === "rejected")
+    .filter(p => p.status === 'rejected')
     .map(p => p.reason);
-  const fulfilledPromises = results.filter(p => p.status !== "rejected");
-  console.log("Errors on SMS Send", errors.length ? errors : "No errors!");
-  console.log("SMS Sent", fulfilledPromises);
+  const fulfilledPromises = results.filter(p => p.status !== 'rejected');
+  console.log('Errors on SMS Send', errors.length ? errors : 'No errors!');
+  console.log('SMS Sent', fulfilledPromises);
 };
 
 exports.sendVerificationCode = (code, number) => {
@@ -36,37 +36,32 @@ exports.sendRoundInvitation = (numbers, roundName, adminName) => {
   return sendSMS(message, numbers);
 };
 
-exports.normalizePhone = (phone, country = "AR") => {
+exports.normalizePhone = (phone, country = 'AR') => {
   let number;
   let finalCountry = country;
 
   try {
     //If the phone number is already formated with a country code it wont throw any error
-    if (isUYPhone(phone)) {
-      finalCountry = "UY";
-      number = phoneUtil.parseAndKeepRawInput(phone, finalCountry);
-    } else {
-      number = phoneUtil.parseAndKeepRawInput(phone, country);
+    number = phoneUtil.parseAndKeepRawInput(phone, country);
 
-      // We remove in Argentina numbers the leading 9 before the area code
-      // We normalize this so we don't have issues with 9 numbers
-      // The 9 is NOT required to send SMS
-      if (number.getNationalNumber().toString()[0] === "9") {
-        const properNumber = number
-          .getNationalNumber()
-          .toString()
-          .substring(1);
-        number = phoneUtil.parseAndKeepRawInput(properNumber, country);
-      }
+    // We remove in Argentina numbers the leading 9 before the area code
+    // We normalize this so we don't have issues with 9 numbers
+    // The 9 is NOT required to send SMS
+    if (number.getNationalNumber().toString()[0] === '9') {
+      const properNumber = number
+        .getNationalNumber()
+        .toString()
+        .substring(1);
+      number = phoneUtil.parseAndKeepRawInput(properNumber, country);
     }
   } catch (error) {
     // If the number above threw error we asume that it's from Argentina ( in the future we should get it from the admin number )
-    console.log("===== ERROR on parsing normalidez phone =====");
-    if (error.message === "Invalid country calling code") {
+    console.log('===== ERROR on parsing normalidez phone =====');
+    if (error.message === 'Invalid country calling code') {
       // Get first number from the phone
-      const { 0: firstNumber } = phone;
+      const {0: firstNumber} = phone;
 
-      if (firstNumber !== "9") {
+      if (firstNumber !== '9') {
         phone = `9 ${phone}`;
       }
 
@@ -77,13 +72,5 @@ exports.normalizePhone = (phone, country = "AR") => {
   }
 
   // Format the phone number to international format
-  return phoneUtil.format(number, PNF.INTERNATIONAL);
-};
-
-const isUYPhone = phone => {
-  const trimPhone = phone.replace(/\s/g, "");
-  return (
-    (trimPhone.length === 9 && trimPhone.substr(0, 2) === "09") ||
-    trimPhone.includes("+598")
-  );
+  return phoneUtil.format(number, PNF.E164);
 };


### PR DESCRIPTION
Remove UY phone condition and format to aidi phone format

https://www.npmjs.com/package/google-libphonenumber
```
// Format number in the E164 format.
phoneUtil.format(number, PNF.E164);
// => +12024561414
```