### PR TITLE
Ajustes para mostrar resultado cuando se vuelve a enviar el registro

### DIFF
--- a/app/src/actions/auth.js
+++ b/app/src/actions/auth.js
@@ -12,7 +12,7 @@ export const createUser = (username, password, name, token, nick) => {
       password,
       name,
       token,
-      nick,
+      nick
     );
 
     if (response.error) {
@@ -65,7 +65,7 @@ export const verifyEmail = (username, password, name, token) => {
       username.trim(),
       password,
       name,
-      token,
+      token
     );
 
     if (!response.error) {
@@ -143,7 +143,7 @@ export const sendPassword = (username, password, token) => {
     const response = await UserService.forgotNewPassword(
       username,
       password,
-      token,
+      token
     );
 
     dispatch(finishLoadingNewPassword(response));
@@ -220,7 +220,7 @@ export const phoneVerifiyCode = (username, phoneNumber, country, code) => {
       username,
       phoneNumber,
       country,
-      code,
+      code
     );
 
     if (!response.error) {
@@ -241,7 +241,6 @@ export const cleanPhone = () => {
 };
 
 export const forceSCRegister = async dispatch => {
-  const errorMessage = "Ocurrió un error al reintentar el registro.";
   dispatch({ type: types.START_FORCE_SC });
   try {
     const user = await getAuth();
@@ -249,13 +248,13 @@ export const forceSCRegister = async dispatch => {
     dispatch({ type: types.FINISH_FORCE_SC });
     if (response && response.data) {
       await setAuth({ ...user, ...response.data });
+      return { error: false };
     } else {
-      console.log(response);
+      return { error: true };
     }
   } catch (error) {
-    console.log(error);
     dispatch({ type: types.FINISH_FORCE_SC });
-    return { error: errorMessage };
+    return { error: true };
   }
 };
 

--- a/app/src/components/components/WarningSCModal.js
+++ b/app/src/components/components/WarningSCModal.js
@@ -16,12 +16,14 @@ const WarningSCModal = ({
   visible,
   onRequestClose,
   onConfirm,
+  onFinish,
   registerSCLoading,
   forceSCRegister,
 }) => {
   const handleConfirm = async () => {
     onConfirm();
-    forceSCRegister();
+    const result = await forceSCRegister();
+    onFinish(result);
   };
 
   return (
@@ -131,5 +133,5 @@ export default connect(
   }),
   dispatch => ({
     forceSCRegister: () => AuthActions.forceSCRegister(dispatch),
-  }),
+  })
 )(WarningSCModal);

--- a/app/src/components/screens/rounds/RoundsList.js
+++ b/app/src/components/screens/rounds/RoundsList.js
@@ -14,6 +14,7 @@ import { setEditRoundData, clearStore } from "../../../actions/roundCreation";
 import { setRouteOptions } from "../../../actions/routeOptions";
 import WarningSCModal from "../../components/WarningSCModal";
 import { notificationsCodes } from "../../../utils/constants";
+import ConfirmModal from "../../components/ConfirmModal";
 
 class RoundsList extends React.Component {
   state = {
@@ -22,6 +23,7 @@ class RoundsList extends React.Component {
     roundEditData: {},
     loading: true,
     showSCModal: false,
+    confirmAlert: null,
   };
 
   async componentDidMount() {
@@ -41,6 +43,7 @@ class RoundsList extends React.Component {
 
   updateAuth = async () => {
     const auth = await getAuth();
+
     this.setState({ auth });
   };
 
@@ -62,8 +65,21 @@ class RoundsList extends React.Component {
 
   async updateSCModal() {
     await this.updateAuth();
+
     this.setState({ showSCModal: false });
   }
+
+  showWarningModalResult = result => {
+    const message = {
+      title: result.error
+        ? "Error al registrarte! Por favor, volvé a intertarlo"
+        : "Reintento enviado con éxito! En unos minutos, recibirás una notificación confirmando tu registro",
+      positive: () => this.setState({ confirmAlert: null }),
+      iconType: this.state.auth === null ? "error" : null,
+    };
+
+    this.setState({ confirmAlert: message });
+  };
 
   filterRounds = (roundsData, currentStatus) => {
     return roundsData.filter(r => {
@@ -264,7 +280,11 @@ class RoundsList extends React.Component {
           visible={showSCModal}
           onRequestClose={this.hideSCWarning}
           onConfirm={() => this.updateSCModal()}
+          onFinish={result => this.showWarningModalResult(result)}
         />
+        {this.state.confirmAlert && (
+          <ConfirmModal {...this.state.confirmAlert} />
+        )}
       </View>
     );
   }
@@ -276,7 +296,7 @@ const mapStateToPropsList = state => {
     nameFromCreation: state.roundCreation.name,
     activePage: state.routeOptions?.roundsList?.page,
     haveFailedRegisterNotification: state.notifications.list.some(
-      item => item.code === notificationsCodes.errorSC,
+      item => item.code === notificationsCodes.errorSC
     ),
   };
 };
@@ -320,5 +340,5 @@ const styles = StyleSheet.create({
 
 export default connect(
   mapStateToPropsList,
-  mapDispatchToPropsList,
+  mapDispatchToPropsList
 )(RoundsList);


### PR DESCRIPTION
Al presionar sobre el boton Reintentar, en el modal de fallo de registro del usuario de ronda, se agregó al finalizar el proceso de reintento de registro, una modal de información, en el que solo se muestra un texto para saber si el reintento fue exitoso o no.