### PR TITLE
fix: take participant from params

### DIFF
--- a/api/services/participant.js
+++ b/api/services/participant.js
@@ -24,9 +24,8 @@ exports.byId = async req => {
 };
 
 exports.acceptRound = async req => {
-  const { roundId } = req.params;
+  const { roundId, participantId } = req.params;
   const { username } = req.body;
-  const { participantId } = req.middlewareData;
 
   // Find participant
   const participant = await participant_manager.findById(participantId);


### PR DESCRIPTION
take participantId from params instead of middlewareData (this used the user who sent the request instead of the one that is trying to accept)