### PR TITLE
Dont even try if the blockchain is syncing

### DIFF
--- a/api/services/blockchain.js
+++ b/api/services/blockchain.js
@@ -381,6 +381,8 @@ const makeTransaction = async (
   exTc = -1,
   setprice
 ) => {
+  const isSyncingResponse = await web3.eth.isSyncing()
+  if (!isSyncingResponse) throw new Error('Node still syncing');
   // TODO: Hay que parametrizar todo esto
   const transactionCount = await web3.eth.getTransactionCount(ownerAddress);
   const gasPrice = await getMinimumGasPrice();
@@ -427,6 +429,12 @@ exports.getTransactionCount = async address => {
 
 exports.sendManyBalanceTx = async (from, fromPk, addresses, amount) => {
   const results = [];
+
+  const isSyncingResponse = await web3.eth.isSyncing()
+  if (!isSyncingResponse) {
+    results.push({ error: 'Node still syncing', success: false });
+    return results;
+  }
   // Failsafe to bail out of infinite errors
   const maxTransactions = addresses.length;
   let counter = 0;
@@ -460,7 +468,7 @@ exports.sendManyBalanceTx = async (from, fromPk, addresses, amount) => {
         throw new Error("Missed timing!");
       }
     } catch (error) {
-      results.push[{ error, success: false }];
+      results.push({ error, success: false });
     }
   }
 


### PR DESCRIPTION
Esto pr pretende detener los intentos de lecturas y escrituras en la blockchain de RSK cundo el nodo se encuentra en estado de sincronización.
Esto de debido a que se llega a un estado inconsistente, intentando realizar refills incorrectos. Estos intentos se acumulan hasta llegar a denegar el uso del nodo a otros componentes.